### PR TITLE
fixes #29 issue (3rd page of text file not updating line numbers)

### DIFF
--- a/libraries/sharedCode/src/main/java/sharedcode/turboeditor/fragment/EditorFragment.java
+++ b/libraries/sharedCode/src/main/java/sharedcode/turboeditor/fragment/EditorFragment.java
@@ -713,6 +713,7 @@ public class EditorFragment extends Fragment implements FindTextDialogFragment.S
         private final EditTextChangeListener
                 mChangeListener;
         int lineCount, realLine;
+        private int startingLine = -1;
         private LineUtils lineUtils;
         private boolean modified = true;
         /**
@@ -854,8 +855,9 @@ public class EditorFragment extends Fragment implements FindTextDialogFragment.S
         public void onDraw(final Canvas canvas) {
 
             if (PreferenceHelper.getLineNumbers(getContext())) {
-                if (lineCount != getLineCount()) {
+                if (startingLine != editorInterface.getPageSystem().getStartingLine()) {
                     lineCount = getLineCount();
+                    startingLine = editorInterface.getPageSystem().getStartingLine();
 
                     lineUtils.updateHasNewLineArray(editorInterface.getPageSystem().getStartingLine(), lineCount, getLayout(), getText().toString());
                 }


### PR DESCRIPTION
I tested turbo-editor with a file containing 10,000 lines and it turns out that, when switching to the third page (and many others), the line number was not updated. Now, it's showing the correct line number.
