### PR TITLE
"Replace all" bug fix

### DIFF
--- a/libraries/sharedCode/src/main/java/sharedcode/turboeditor/activity/MainActivity.java
+++ b/libraries/sharedCode/src/main/java/sharedcode/turboeditor/activity/MainActivity.java
@@ -526,7 +526,10 @@ public abstract class MainActivity extends ActionBarActivity implements IHomeAct
     // region OTHER THINGS
     void replaceText(boolean all) {
         if (all) {
-            mEditor.setText(pageSystem.getAllText(mEditor.getText().toString()).replaceAll(searchResult.whatToSearch, searchResult.textToReplace));
+            if (searchResult.isRegex)
+                mEditor.setText(pageSystem.getAllText(mEditor.getText().toString()).replaceAll(searchResult.whatToSearch, searchResult.textToReplace));
+            else
+                mEditor.setText(pageSystem.getAllText(mEditor.getText().toString()).replace(searchResult.whatToSearch, searchResult.textToReplace));
 
             searchResult = null;
             invalidateOptionsMenu();

--- a/libraries/sharedCode/src/main/java/sharedcode/turboeditor/dialogfragment/FindTextDialog.java
+++ b/libraries/sharedCode/src/main/java/sharedcode/turboeditor/dialogfragment/FindTextDialog.java
@@ -193,7 +193,7 @@ public class FindTextDialog extends DialogFragment {
                     return;
                     // else we return positions and other things
                 else {
-                    SearchResult searchResult = new SearchResult(foundIndex, textToFind.length(), replaceCheck.isChecked(), textToFind.getText().toString(), textToReplace.getText().toString());
+                    SearchResult searchResult = new SearchResult(foundIndex, textToFind.length(), replaceCheck.isChecked(), textToFind.getText().toString(), textToReplace.getText().toString(), regexCheck.isChecked());
                     searchDialogInterface.onSearchDone(searchResult);
                 }
             } else {

--- a/libraries/sharedCode/src/main/java/sharedcode/turboeditor/texteditor/SearchResult.java
+++ b/libraries/sharedCode/src/main/java/sharedcode/turboeditor/texteditor/SearchResult.java
@@ -29,14 +29,16 @@ public class SearchResult {
     public String textToReplace;
     public int index;
     public String whatToSearch;
+    public boolean isRegex;
 
 
-    public SearchResult(LinkedList<Integer> foundIndex, int textLength, boolean isReplace, String whatToSearch, String textToReplace) {
+    public SearchResult(LinkedList<Integer> foundIndex, int textLength, boolean isReplace, String whatToSearch, String textToReplace, boolean isRegex) {
         this.foundIndex = foundIndex;
         this.textLength = textLength;
         this.isReplace = isReplace;
         this.whatToSearch = whatToSearch;
         this.textToReplace = textToReplace;
+        this.isRegex = isRegex;
     }
 
     public void doneReplace() {


### PR DESCRIPTION
"Replace all" disregards the "Regular expression" checkbox and always treats the search string as a regular expression.

Initial file contents:
aaa.
bbb.
ccc.

Find -> Text to find: ".", Regular expression unchecked, check Replace, Text to replace: "x" -> Find -> Replace all

Result:
xxxx
xxxx
xxxx
