### PR TITLE
Support opening .org files

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,6 +76,7 @@
                 <data android:pathPattern=".*\\.md"/>
                 <data android:pathPattern=".*\\.php" />
                 <data android:pathPattern=".*\\.py" />
+                <data android:pathPattern=".*\\.org" />
             </intent-filter>
             <intent-filter >
                 <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
Org (organization) files are common among emacs developers. If you're not familiar with it, it's kind of like markdown. It would be nice to be able to automatically open these.
