### PR TITLE
JDK 8 build compatibility fix

### DIFF
--- a/app-pro/build.gradle
+++ b/app-pro/build.gradle
@@ -34,8 +34,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
     }
     buildTypes {
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,8 +52,8 @@ android {
         versionName "1.19"
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
     }
     buildTypes {
         release {


### PR DESCRIPTION
Currently, turbo edit doesn't build with JDK 8 and none of the modern toolsets support or will work with JDK 7 anymore. This commit makes it build with JDK 8.